### PR TITLE
Accessors should be synchronized as well, otherwise ConcurrentModificationException

### DIFF
--- a/munit-core/munit-common/src/main/java/org/mule/munit/common/mp/MockedMessageProcessorManager.java
+++ b/munit-core/munit-common/src/main/java/org/mule/munit/common/mp/MockedMessageProcessorManager.java
@@ -56,7 +56,7 @@ public class MockedMessageProcessorManager extends MessageProcessorManager
      * Reset all the status
      * </p>
      */
-    public void reset()
+    public synchronized void reset()
     {
         behaviors.clear();
         calls.clear();
@@ -73,7 +73,7 @@ public class MockedMessageProcessorManager extends MessageProcessorManager
      * @param attributesMatchers The attributes that the message processor must match
      * @return The List of message processor calls
      */
-    public List<MessageProcessorCall> findCallsFor(MessageProcessorId mpId, Map<String, Object> attributesMatchers)
+    public synchronized List<MessageProcessorCall> findCallsFor(MessageProcessorId mpId, Map<String, Object> attributesMatchers)
     {
         List<MessageProcessorCall> expected = new ArrayList<MessageProcessorCall>();
         MessageProcessorCall matchingCall = new MessageProcessorCall(mpId);
@@ -96,7 +96,7 @@ public class MockedMessageProcessorManager extends MessageProcessorManager
      * @param messageProcessorCall The comparing call
      * @return The best matching Before spy assertion
      */
-    public SpyAssertion getBetterMatchingBeforeSpyAssertion(MessageProcessorCall messageProcessorCall)
+    public synchronized SpyAssertion getBetterMatchingBeforeSpyAssertion(MessageProcessorCall messageProcessorCall)
     {
         return getBetterMatchingAction(messageProcessorCall, beforeCallSpyAssertions);
     }
@@ -110,7 +110,7 @@ public class MockedMessageProcessorManager extends MessageProcessorManager
      * @param messageProcessorCall The comparing call
      * @return The best matching After spy assertion
      */
-    public SpyAssertion getBetterMatchingAfterSpyAssertion(MessageProcessorCall messageProcessorCall)
+    public synchronized SpyAssertion getBetterMatchingAfterSpyAssertion(MessageProcessorCall messageProcessorCall)
     {
         return getBetterMatchingAction(messageProcessorCall, afterCallSpyAssertions);
     }
@@ -130,7 +130,7 @@ public class MockedMessageProcessorManager extends MessageProcessorManager
         afterCallSpyAssertions.add(spyAssertion);
     }
 
-    public List<MunitMessageProcessorCall> getCalls()
+    public synchronized List<MunitMessageProcessorCall> getCalls()
     {
         return new LinkedList<MunitMessageProcessorCall>(calls);
     }


### PR DESCRIPTION
We've got ConcurrentModificationException in our project. After some research we found that accessors are not guarded against modifications. Namely there are list iterators in org.mule.munit.common.mp.MockedMessageProcessorManager#findCallsFor() and several methods in superclass that are not synchronized. Please consider this pull request which fixes the issue.